### PR TITLE
Allow multiple whitespaces after module name

### DIFF
--- a/src/Proofread/Parser.hs
+++ b/src/Proofread/Parser.hs
@@ -63,7 +63,7 @@ docModule :: Parser Text
 docModule = do
     _                   <- one (string "module ")
     moduleName          <- some (alphaNumChar `or` char '.' `or` char '_')
-    _                   <- one spaceCharacter
+    _                   <- some whitespace
     _                   <- manyTill anyChar (string "\n\n")
 
     return $ Text.pack moduleName

--- a/tests/fixtures/MultilineHeader.elm
+++ b/tests/fixtures/MultilineHeader.elm
@@ -1,0 +1,9 @@
+module MultilineHeader
+    exposing
+        ( add
+        )
+
+
+add : number -> number -> number
+add x y =
+    Debug.log "ignoreThis" (x + y)


### PR DESCRIPTION
This is a nice tool, and I've been quietly using it for a little while. From what I can tell, you're intentionally supporting a subset of Elm, which makes sense. My guess was this is supposed to work with most `elm-format`-ed modules(?). This PR fixes a bug in the case where `elm-format` expands the module header across multiple lines.

I added a test fixture for reference, but as far as I can tell those aren't run in any automated setting.